### PR TITLE
Issue 82 remove unused parameter in curation logic

### DIFF
--- a/src/token/ERC721/strategies/curation/logic/CurationLogic.sol
+++ b/src/token/ERC721/strategies/curation/logic/CurationLogic.sol
@@ -144,7 +144,7 @@ contract CurationLogic is IERC721PressLogic, ICurationLogic, CurationStorageV1 {
         return true;
     }                   
 
-    /// @notice checks burun access for a given burn caller
+    /// @notice checks burn access for a given burn caller
     /// @param targetPress press contract to check access for
     /// @param tokenId tokenId to check access for
     /// @param burnCaller address of burnCaller to check access for
@@ -153,7 +153,7 @@ contract CurationLogic is IERC721PressLogic, ICurationLogic, CurationStorageV1 {
         uint256 tokenId,
         address burnCaller
     ) external view requireInitialized(targetPress) returns (bool) {
-        // check if burnCaller caller has burn access for given target Press
+        // check if burnCaller has burn access for given target Press
         if (configInfo[targetPress].accessControl.getAccessLevel(targetPress, burnCaller) < ADMIN) {
             return false;
         }

--- a/src/token/ERC721/strategies/curation/logic/CurationLogic.sol
+++ b/src/token/ERC721/strategies/curation/logic/CurationLogic.sol
@@ -146,11 +146,9 @@ contract CurationLogic is IERC721PressLogic, ICurationLogic, CurationStorageV1 {
 
     /// @notice checks burun access for a given burn caller
     /// @param targetPress press contract to check access for
-    /// @param tokenId tokenId to check access for
     /// @param burnCaller address of burnCaller to check access for
     function canBurn(
-        address targetPress, 
-        uint256 tokenId,
+        address targetPress,
         address burnCaller
     ) external view requireInitialized(targetPress) returns (bool) {
         // check if burnCaller caller has burn access for given target Press

--- a/src/token/ERC721/strategies/curation/logic/CurationLogic.sol
+++ b/src/token/ERC721/strategies/curation/logic/CurationLogic.sol
@@ -146,9 +146,11 @@ contract CurationLogic is IERC721PressLogic, ICurationLogic, CurationStorageV1 {
 
     /// @notice checks burun access for a given burn caller
     /// @param targetPress press contract to check access for
+    /// @param tokenId tokenId to check access for
     /// @param burnCaller address of burnCaller to check access for
     function canBurn(
-        address targetPress,
+        address targetPress, 
+        uint256 tokenId,
         address burnCaller
     ) external view requireInitialized(targetPress) returns (bool) {
         // check if burnCaller caller has burn access for given target Press


### PR DESCRIPTION
Hey @salieflewis 
This PR is for the issue #82 
As per our interaction in the actual issue, my understanding is that we cannot remove the unused parameters. So just fixing typos in the comments for now.
Let me know if I need to change anything.